### PR TITLE
fix stringify

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -296,6 +296,7 @@ function isJsonType(contentType) {
 }
 
 function stringify(obj) {
+  obj = JSON.parse(JSON.stringify(obj))
   return Object.keys(obj).map(key => {
     return key + '=' + obj[key]
   }).join('&')

--- a/test/case/basic.js
+++ b/test/case/basic.js
@@ -173,6 +173,20 @@ module.exports = Fetch => {
           equal(body.headers['Content-Type'], undefined)
         })
       })
+
+      it('get() should ignore prop if value is undefined', () => {
+        return request
+        .get(host + '/get')
+        .query({name: undefined})
+        .then(res => {
+          equal(res.status, 200)
+          equal(res.headers.get('Content-Type'), jsonType)
+          return res.json()
+        })
+        .then(body => {
+          equal(Object.keys(body.args).length, 0)
+        })
+      })
     })
 
     describe('# set', () => {


### PR DESCRIPTION
#45 

这样就不用每次 query() 时都要先` pickby(param, v => !isUndefined(v)) `一次