### PR TITLE
fix async afterResponse

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -245,8 +245,8 @@ class Request {
     if (afterResponse) {
       return fetch(url, options)
         .then(res => {
-          afterResponse(res)
-          return res
+          return Promise.resolve(afterResponse(res))
+            .then(() => res.clone())
         })
     }
 

--- a/test/case/basic.js
+++ b/test/case/basic.js
@@ -411,16 +411,16 @@ module.exports = Fetch => {
           }
         })
 
-        await req
-        .get(host + '/status/401')
-        .json()
-        .then(() => {
+        try {
+          await req
+          .get(host + '/status/401')
+          .json()
           called = true
-        })
-        .catch(() => {})
-        .then(() => {
+        } catch(e) {
+          
+        } finally {
           equal(called, false)
-        })
+        }
       })
     })
   })

--- a/test/case/basic.js
+++ b/test/case/basic.js
@@ -401,6 +401,33 @@ module.exports = Fetch => {
           equal(called, true)
         })
       })
+
+      it('async with error', async () => {
+        let called = false
+
+        const req = new Fetch({
+          afterResponse: async (res) => {
+            if (!res.ok) {
+              throw new Error('response not ok')
+            }
+          }
+        })
+
+        const api = () => {
+          return req
+            .get(host + '/status/401')
+            .text()
+        }
+
+        try {
+          await api()
+          called = true
+        } catch(e) {
+
+        } finally {
+          equal(called, false)
+        }
+      })
     })
   })
 }

--- a/test/case/basic.js
+++ b/test/case/basic.js
@@ -406,27 +406,20 @@ module.exports = Fetch => {
         let called = false
 
         const req = new Fetch({
-          afterResponse: async (res) => {
-            if (!res.ok) {
-              throw new Error('response not ok')
-            }
+          afterResponse: async () => {
+            throw new Error('response not ok')
           }
         })
 
-        const api = () => {
-          return req
-            .get(host + '/status/401')
-            .text()
-        }
-
-        try {
-          await api()
+        await req
+        .get(host + '/status/401')
+        .json()
+        .then(() => {
           called = true
-        } catch(e) {
-
-        } finally {
+        })
+        .catch(() => {
           equal(called, false)
-        }
+        })
       })
     })
   })

--- a/test/case/basic.js
+++ b/test/case/basic.js
@@ -417,7 +417,8 @@ module.exports = Fetch => {
         .then(() => {
           called = true
         })
-        .catch(() => {
+        .catch(() => {})
+        .then(() => {
           equal(called, false)
         })
       })


### PR DESCRIPTION
 fix Bug: afterResponse 如果是 async 函数, 函数中 throw Error 不能正确中断主流程

原因: 实现中忽略了 afterResponse 可能返回 Promise 的情况